### PR TITLE
Eliminate i18n folder

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 1.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update French translations.
+  [jone]
+
+- Move plone translations from i18n to locales folder.
+  [jone]
 
 
 1.2.6 (2013-05-13)

--- a/ftw/journal/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/journal/locales/de/LC_MESSAGES/plone.po
@@ -1,5 +1,3 @@
-# Gettext Message File for ftwplatformv1.
-# 4teamwork <info@4teamwork.ch>, 2005.
 msgid ""
 msgstr ""
 "Project-Id-Version: ftw_Platform_v1 0.9\n"
@@ -11,12 +9,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Language-Code: de\n"
-"Language-Name: Deutsch\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: plone\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
 msgid "label_journal_entry"
 msgstr "Journaleintrag"
+
 

--- a/ftw/journal/locales/fr/LC_MESSAGES/plone.po
+++ b/ftw/journal/locales/fr/LC_MESSAGES/plone.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+msgid "label_journal_entry"
+msgstr "Entrée journal"
+
+

--- a/ftw/journal/locales/plone.pot
+++ b/ftw/journal/locales/plone.pot
@@ -1,0 +1,22 @@
+# Gettext Message File for ftwplatformv1.
+# 4teamwork <info@4teamwork.ch>, 2005.
+msgid ""
+msgstr ""
+"Project-Id-Version: ftw_Platform_v1 0.9\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"PO-Revision-Date: 2008-05-25 13:23+0100\n"
+"Last-Translator: \n"
+"Language-Team: Deutsch <info@4teamwork.ch>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Language-Code: de\n"
+"Language-Name: Deutsch\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: plone\n"
+"X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
+
+msgid "label_journal_entry"
+msgstr ""
+


### PR DESCRIPTION
- Move `plone` translations from `i18n` to `locales`
- Add missing translation in `plone` domain for `fr`
- Fix changelog of previous release 1.2.6

/cc @maethu 
