### PR TITLE
Whitelist journal storage writes as safe with a plone.protect > 3.0

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Whitelist journal writes for plone.protect > 3.0
+  [Rotonen]
 
 
 1.2.8 (2014-09-23)

--- a/ftw/journal/adapters/annotations_journal.py
+++ b/ftw/journal/adapters/annotations_journal.py
@@ -16,17 +16,19 @@ class AnnotationsJournalizable(object):
     def __call__(self, action, comment, actor, time):
         context = self.context
         annotations = IAnnotations(context)
-        journal_annotations = annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, None)
+        journal_annotations = annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY,
+                                              None)
 
         if not journal_annotations:
             annotations[JOURNAL_ENTRIES_ANNOTATIONS_KEY] = PersistentList()
-            journal_annotations = annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY)
+            journal_annotations = annotations.get(
+                JOURNAL_ENTRIES_ANNOTATIONS_KEY)
 
         history_entry = PersistentDict({
-                         'action' : action,
-                         'comments' : comment,
-                         'actor' : actor,
-                         'time' : time,
+                         'action': action,
+                         'comments': comment,
+                         'actor': actor,
+                         'time': time,
                          })
         journal_annotations.append(history_entry)
         context._p_changed = True

--- a/ftw/journal/adapters/annotations_journal.py
+++ b/ftw/journal/adapters/annotations_journal.py
@@ -31,4 +31,3 @@ class AnnotationsJournalizable(object):
                          'time': time,
                          })
         journal_annotations.append(history_entry)
-        context._p_changed = True

--- a/ftw/journal/adapters/annotations_journal.py
+++ b/ftw/journal/adapters/annotations_journal.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
+from plone.protect import utils
 from zope.annotation.interfaces import IAnnotations, IAnnotatable
 from zope.interface import alsoProvides
 
@@ -30,4 +31,10 @@ class AnnotationsJournalizable(object):
                          'actor': actor,
                          'time': time,
                          })
+
+        # If we have plone.protect > 3.0, mark the journal write as safe
+        if 'safeWrite' in dir(utils):
+            utils.safeWrite(context)
+            utils.safeWrite(journal_annotations)
+
         journal_annotations.append(history_entry)

--- a/ftw/journal/adapters/workflow_history_journal.py
+++ b/ftw/journal/adapters/workflow_history_journal.py
@@ -1,5 +1,5 @@
 from Acquisition import aq_inner
-
+from plone.protect import utils
 from Products.CMFCore.utils import getToolByName
 
 
@@ -28,5 +28,10 @@ class WorkflowHistoryJournalizable(object):
                          'actor': actor,
                          'time': time,
                          }
+
+        # If we have plone.protect > 3.0, mark the journal write as safe
+        if 'safeWrite' in dir(utils):
+            utils.safeWrite(context)
+            utils.safeWrite(review_state)
 
         workflow_tool.setStatusOf(workflow_id, context, history_entry)

--- a/ftw/journal/adapters/workflow_history_journal.py
+++ b/ftw/journal/adapters/workflow_history_journal.py
@@ -5,28 +5,28 @@ from Products.CMFCore.utils import getToolByName
 
 class WorkflowHistoryJournalizable(object):
     """Adapter to create journal entries in the workflow history"""
-    
+
     def __init__(self, context):
         self.context = aq_inner(context)
 
     def __call__(self, action, comment, actor, time):
         context = self.context
         workflow_tool = getToolByName(context, 'portal_workflow')
-        
+
         workflows = workflow_tool.getWorkflowsFor(context)
-        
+
         if not workflows:
             return
-        
+
         workflow_id = workflows[0].id
         review_state = workflow_tool.getInfoFor(context, 'review_state', None)
 
         history_entry = {
-                         'action' : action,
-                         'review_state' : review_state,
-                         'comments' : comment,
-                         'actor' : actor,
-                         'time' : time,
+                         'action': action,
+                         'review_state': review_state,
+                         'comments': comment,
+                         'actor': actor,
+                         'time': time,
                          }
-    
+
         workflow_tool.setStatusOf(workflow_id, context, history_entry)

--- a/ftw/journal/tests/test_unit_adapters.py
+++ b/ftw/journal/tests/test_unit_adapters.py
@@ -43,7 +43,6 @@ class TestFtwJournalAdapters(MockTestCase):
         self.assertIn('saved new file', values)
         self.assertIn('ratman', values)
         self.assertIn('15:18', values)
-        self.assertTrue(adapter.context._p_changed)
 
     def test_workflow_history_journal(self):
         """ Test workflow history journal adapter


### PR DESCRIPTION
* Check for presence of safeWrite() in plone.protect
* Flag annotations as safe writes
* Flag workflow_history entries as safe writes
* Tests for write whitelisting are on the responsibility of the projects using plone.protect > 3.0

Fixes #6 