### PR TITLE
Add uuid4 id for annotation journal entries

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add uuid4 id for new annotation journal entries. [elioschmutz]
 
 
 1.3.0 (2019-09-05)

--- a/ftw/journal/adapters/annotations_journal.py
+++ b/ftw/journal/adapters/annotations_journal.py
@@ -3,6 +3,7 @@ from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone.protect import utils
+from uuid import uuid4
 from zope.annotation.interfaces import IAnnotations, IAnnotatable
 from zope.interface import alsoProvides
 
@@ -26,6 +27,7 @@ class AnnotationsJournalizable(object):
                 JOURNAL_ENTRIES_ANNOTATIONS_KEY)
 
         history_entry = PersistentDict({
+                         'id': str(uuid4()),
                          'action': action,
                          'comments': comment,
                          'actor': actor,

--- a/ftw/journal/tests/test_integration.py
+++ b/ftw/journal/tests/test_integration.py
@@ -31,9 +31,24 @@ class TestFtwJournalIntegration(unittest.TestCase):
         journal = IAnnotations(doc).get(JOURNAL_ENTRIES_ANNOTATIONS_KEY)[0]
 
         self.assertTrue('modified' in journal.get('action'))
+        self.assertTrue(type(journal.get('id')) == str)
         self.assertTrue('added new line' in journal.get('comments'))
         self.assertTrue(TEST_USER_ID in journal.get('actor'))
         self.assertTrue(DateTime().Date() in journal.get('time').Date())
+
+    def test_annotations_journal_id_is_unique(self):
+        portal = self.layer['portal']
+        folder = portal[portal.invokeFactory('Folder', 'f1', )]
+        doc = folder[folder.invokeFactory('Document', 'd1', )]
+
+        alsoProvides(doc, IAnnotationsJournalizable)
+
+        notify(JournalEntryEvent(doc, "added new line", "modified"))
+        notify(JournalEntryEvent(doc, "added another line", "modified"))
+
+        journal = IAnnotations(doc).get(JOURNAL_ENTRIES_ANNOTATIONS_KEY)
+
+        self.assertNotEqual(journal[0].get('id'), journal[1].get('id'))
 
     def test_event_workflow_history(self):
         """ Test the event with IWorkflowHistoryJournalizable interface


### PR DESCRIPTION
This PR extends the annotation journal entries with an `id`.

This is useful if we want to target journal entries to modify or delete.

Only new entries will have an `id`. We do not provide an upgrade-step for existing entries.